### PR TITLE
Fix: Allow CORS from any origin to enable API access from external tools

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -21,12 +21,13 @@ app.use(ipBlockMiddleware);
 // for parsing user data
 app.use(express.json());
 
-// CORS setup for frontend domain access
+// CORS setup to allow access from any origin (including Postman and other tools)
 const FRONTEND_ORIGIN = process.env.FRONTEND_ORIGIN || "*";
 app.use(cors({
-  origin: FRONTEND_ORIGIN === "*" ? true : FRONTEND_ORIGIN,
+  origin: "*", // Allow any origin to access the API
   credentials: true,
   methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+  exposedHeaders: ["Content-Length", "Content-Type"],
 }));
 
 // Apply general rate limiting to all routes


### PR DESCRIPTION
This PR fixes an issue where the API could only be accessed from the copy-paste.space frontend.

Changes:
- Modified CORS configuration to allow requests from any origin
- Added exposedHeaders to ensure all necessary headers are accessible
- This enables tools like Postman to access the API endpoints

Testing:
- Tested API access using Postman
- Verified that the frontend still works correctly